### PR TITLE
BRE-1040 Dockerfiles shared ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+
+# Default shared ownership of Dockerfile
+**/Dockerfile @bitwarden/team-appsec @bitwarden/dept-bre
+**/*.dockerignore @bitwarden/team-appsec @bitwarden/dept-bre
+**/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-bre


### PR DESCRIPTION
[BRE-1040](https://bitwarden.atlassian.net/browse/BRE-1040)

Include AppSec team and BRE dept for repository-level ownership of Dockerfile, and Dockerfile related, files.
